### PR TITLE
Experiments with native math support

### DIFF
--- a/bruijn/Circle.bruijn
+++ b/bruijn/Circle.bruijn
@@ -13,6 +13,11 @@ split y [[[[fixOr [0 (4 ++3 --(2 ⋅ (+2)) (1 ⋅ (+2))) (4 ++3 (2 ⋅ (+2)) (1 
 
 main [split (+0) (+1) (+1)]
 
+# WORKING half-circle
+y = \(\(0 0) \(1 (0 0)))
+split = (y \\\\(gt (dec (pow <2> 2)) (sqrt (add (pow 1 <2>) (pow 0 <2>))) \\1 \(0 (4 (inc 3) (dec (mul 2 <2>)) (mul 1 <2>)) (4 (inc 3) (mul 2 <2>) (mul 1 <2>)) (4 (inc 3) (dec (mul 2 <2>)) (dec (mul 1 <2>))) (4 (inc 3) (mul 2 <2>) (dec (mul 1 <2>))))))
+\(split <0> <1> <1>)
+
 # y = \(\(0 0) \(1 (0 0)))
-# split = (y \\\\(gt (sqrt (add (pow 1 <2>) (pow 0 <2>))) <50> \\0 \(0 (4 (inc 3) (dec (mul 2 <2>)) (mul 1 <2>)) (4 (inc 3) (mul 2 <2>) (mul 1 <2>)) (4 (inc 3) (dec (mul 2 <2>)) (dec (mul 1 <2>))) (4 (inc 3) (mul 2 <2>) (dec (mul 1 <2>))))))
-# \(split <0> <1> <1>)
+# split = (y \\\(eq (mod (log (add 1 0)) <2>) <1> \\1 \(0 (3 (dec 2) (dec 1)) (3 (dec 2) (inc 1)) (3 (inc 2) (dec 1)) (3 (inc 2) (inc 1)))))
+# \(split <1> <1>)

--- a/bruijn/Circle.bruijn
+++ b/bruijn/Circle.bruijn
@@ -1,0 +1,18 @@
+:import std/Combinator .
+:import std/Math .
+
+# depth → dist → screen
+# upper left quadrant
+# split y [[[fixOr [0 (3 ++2 ++(++1)) (3 ++2 ++1) (3 ++2 ++1) (3 ++2 1)]]]]
+# 	fixOr 0 >? (+5) [[1]]
+
+# depth → x → y → screen
+# upper right quadrant
+split y [[[[fixOr [0 (4 ++3 --(2 ⋅ (+2)) (1 ⋅ (+2))) (4 ++3 (2 ⋅ (+2)) (1 ⋅ (+2))) (4 ++3 --(2 ⋅ (+2)) --(1 ⋅ (+2))) (4 ++3 (2 ⋅ (+2)) --(1 ⋅ (+2)))]]]]]
+	fixOr (sqrt ((1 ** (+2)) + (0 ** (+2)))) >? ((+4) ** 2) [[0]]
+
+main [split (+0) (+1) (+1)]
+
+# y = \(\(0 0) \(1 (0 0)))
+# split = (y \\\\(gt (sqrt (add (pow 1 <2>) (pow 0 <2>))) <50> \\0 \(0 (4 (inc 3) (dec (mul 2 <2>)) (mul 1 <2>)) (4 (inc 3) (mul 2 <2>) (mul 1 <2>)) (4 (inc 3) (dec (mul 2 <2>)) (dec (mul 1 <2>))) (4 (inc 3) (mul 2 <2>) (dec (mul 1 <2>))))))
+# \(split <0> <1> <1>)

--- a/bruijn/Experiments.bruijn
+++ b/bruijn/Experiments.bruijn
@@ -43,3 +43,10 @@ cantor-dust [y [build tl tr bl br]]
 	tr [[0 1 1 1 1]] (build b 0 b b)
 	bl [[0 1 1 1 1]] (build b b 0 b)
 	br [[0 1 1 1 1]] (build b b b 0)
+
+# WEIRD sierpinski
+# x → y → screen
+weird [split (+0) (+0)]
+	split y [[[fixOr1 [0 (3 --2 --1) (3 ++2 --1) (3 --2 ++1) (3 ++2 ++1)]]]]
+		fixOr1 |(1 + 0) >? (+5) [[1]]
+		fixOr2 (|1 + |0) >? (+5) [[1]]

--- a/index.html
+++ b/index.html
@@ -229,6 +229,14 @@ b = \\\\(y \\(0 1 \(0 3 \\0 5 6) \(0 3 4 \\0 6) 1))
               Recursive Nonsense
             </option>
             <option
+              value="y = \(\(0 0) \(1 (0 0)))
+c = \\\(2 0 1)
+split = (y \\\\(eq (mod (max 1 0) <3>) <0> 2 \(0 (4 3 (dec (mul 2 <2>)) (mul 1 <2>)) (4 (c 3) (mul 2 <2>) (mul 1 <2>)) (4 (c 3) (dec (mul 2 <2>)) (dec (mul 1 <2>))) (4 3 (mul 2 <2>) (dec (mul 1 <2>))))))
+\(split \\0 <1> <1>)"
+            >
+              Chebyshev Modulo
+            </option>
+            <option
               value="-- some common definitions for copy-pasting
 w = \\1
 b = \\0

--- a/index.html
+++ b/index.html
@@ -365,7 +365,7 @@ map = \\(0 \\\\\(0 (6 4) (6 3) (6 2) (6 1)))
               ? (stack) => stack.shift()
               : (stack) =>
                   stack.splice(Math.floor(Math.random() * stack.length), 1)[0];
-        const caching = window.cachingConfig.checked;
+        const caching = false; // window.cachingConfig.checked;
         const logger = (str) => {
           window.debugInfo.innerHTML += str;
         };
@@ -402,6 +402,7 @@ map = \\(0 \\\\\(0 (6 4) (6 3) (6 2) (6 1)))
 
       window.render.addEventListener("click", () => {
         const t = parse(window.term.value);
+        console.log(show(t));
         render(t);
         params.searchParams.set("term", encodeBase64(t));
         window.history.pushState({ path: params.href }, "", params.href);

--- a/index.html
+++ b/index.html
@@ -389,11 +389,11 @@ map = \\(0 \\\\\(0 (6 4) (6 3) (6 2) (6 1)))
         }, 0);
       };
 
-      if (params.searchParams.has("term")) {
-        const t = parseBLC(decodeBase64(params.searchParams.get("term")))[0];
-        window.term.innerText = show(t);
-        render(t);
-      }
+      // if (params.searchParams.has("term")) {
+      //   const t = parseBLC(decodeBase64(params.searchParams.get("term")))[0];
+      //   window.term.innerText = show(t);
+      //   render(t);
+      // }
 
       window.examples.addEventListener("change", () => {
         clearScreen(worker);

--- a/index.html
+++ b/index.html
@@ -365,7 +365,7 @@ map = \\(0 \\\\\(0 (6 4) (6 3) (6 2) (6 1)))
               ? (stack) => stack.shift()
               : (stack) =>
                   stack.splice(Math.floor(Math.random() * stack.length), 1)[0];
-        const caching = false; // window.cachingConfig.checked;
+        const caching = window.cachingConfig.checked;
         const logger = (str) => {
           window.debugInfo.innerHTML += str;
         };

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 let MAXRES = 2;
-let doCache = false;
+let doCache = true;
 
 let errors = [];
 const error = (s) => {
@@ -513,7 +513,7 @@ const subst = (i, t, s) => {
       newT = t; // TODO: in THEORY we could handle nums as Church here!
       break;
     case "ope":
-      newT = structuredClone(t); // TODO: clone should be unnecessary
+      newT = t;
       newT.args = newT.args.map((arg) => subst(i, arg, s));
       break;
   }
@@ -535,7 +535,7 @@ const gnf = (t) => {
       const _left = gnf(t.left);
       if (_left === null) return null;
       return _left.type === "abs"
-        ? gnf(subst(0, structuredClone(_left.body), structuredClone(t.right)))
+        ? gnf(subst(0, _left.body, t.right))
         : app(_left)(gnf(t.right));
     case "abs":
       return abs(gnf(t.body));
@@ -612,10 +612,7 @@ const whnf = (t) => {
     case "app":
       const _left = whnf(t.left);
       if (_left === null) return null;
-      if (_left.type === "abs")
-        newT = whnf(
-          subst(0, structuredClone(_left.body), structuredClone(t.right)),
-        );
+      if (_left.type === "abs") newT = whnf(subst(0, _left.body, t.right));
       else if (_left.type === "ope") {
         newT = applyOp(structuredClone(_left), whnf(t.right));
       } else newT = app(_left)(t.right);
@@ -654,8 +651,7 @@ const snf = (_t) => {
     switch (t.type) {
       case "app":
         const _left = whnf(t.left);
-        if (_left.type === "abs")
-          t = subst(0, structuredClone(_left.body), structuredClone(t.right));
+        if (_left.type === "abs") t = subst(0, _left.body, t.right);
         else if (_left.type === "ope") {
           _left.args.map((arg) => whnf(arg));
           t = applyOp(structuredClone(_left), whnf(t.right));

--- a/main.js
+++ b/main.js
@@ -134,10 +134,15 @@ const operators = [
   { name: "mul", arity: 2, args: [] },
   { name: "div", arity: 2, args: [] },
   { name: "pow", arity: 2, args: [] },
+  { name: "max", arity: 2, args: [] },
+  { name: "min", arity: 2, args: [] },
   { name: "mod", arity: 2, args: [] },
   { name: "eq", arity: 2, args: [] },
   { name: "gt", arity: 2, args: [] },
   { name: "ge", arity: 2, args: [] },
+  { name: "lt", arity: 2, args: [] },
+  { name: "le", arity: 2, args: [] },
+  { name: "prime", arity: 1, args: [] },
   { name: "sqrt", arity: 1, args: [] },
   { name: "inc", arity: 1, args: [] },
   { name: "dec", arity: 1, args: [] },
@@ -349,7 +354,7 @@ const parseBLC = (str) => {
 const parseTerm = (str) => {
   const t = /^[01]+$/.test(str) ? parseBLC(str)[0] : parseLam(str)[0];
   if (isOpen(t)) {
-    error("is open");
+    error("is open " + show(t));
     return null;
   } else {
     return t;
@@ -547,8 +552,20 @@ const gnf = (t) => {
   }
 };
 
+const isPrime = (num) => {
+  for (let i = 2, s = Math.sqrt(num); i <= s; i++) {
+    if (num % i === 0) return false;
+  }
+  console.log(num, num > 1);
+  return num > 1;
+};
+
 const evalOp = (obj) => {
-  if (obj.arity !== 0 || obj.args.every((arg) => arg.type != "num")) return obj;
+  if (
+    obj.arity !== 0 ||
+    (obj.args.every((arg) => arg.type != "num") && obj.name != "log")
+  )
+    return obj;
 
   switch (obj.name) {
     case "add":
@@ -561,6 +578,10 @@ const evalOp = (obj) => {
       return num(Math.floor(obj.args[0].n / obj.args[1].n));
     case "pow":
       return num(Math.pow(obj.args[0].n, obj.args[1].n));
+    case "max":
+      return num(Math.max(obj.args[0].n, obj.args[1].n));
+    case "min":
+      return num(Math.min(obj.args[0].n, obj.args[1].n));
     case "mod":
       return num(obj.args[0].n % obj.args[1].n);
     case "eq":
@@ -569,6 +590,12 @@ const evalOp = (obj) => {
       return abs(abs(idx(obj.args[0].n > obj.args[1].n ? 1 : 0)));
     case "ge":
       return abs(abs(idx(obj.args[0].n >= obj.args[1].n ? 1 : 0)));
+    case "lt":
+      return abs(abs(idx(obj.args[0].n < obj.args[1].n ? 1 : 0)));
+    case "le":
+      return abs(abs(idx(obj.args[0].n <= obj.args[1].n ? 1 : 0)));
+    case "prime":
+      return abs(abs(idx(isPrime(obj.args[0].n) ? 1 : 0)));
     case "sqrt":
       return num(Math.floor(Math.sqrt(obj.args[0].n)));
     case "inc":
@@ -640,7 +667,7 @@ const snf = (_t) => {
   let t = whnf(_t);
   if (t === null || t.type !== "abs") {
     console.log(t);
-    error("not a screen/pixel " + show(t));
+    error("not a screen/pixel: " + show(_t) + " \n\nWHNF of\n\n" + show(t));
     return null;
   }
 


### PR DESCRIPTION
This adds some builtin functions for native math operators. Theoretically we could add a 1:1 correspondence to Church operators such that substituting on a builtin operator would actually behave the same as on pure lambda terms -- this would also enable base64 encoding in the URL (which could be decoded while parsing to the builtin operators)

The current state is quite chaotic since our reduction is inherently flawed (see #2), so this will remain a proof-of-concept for now.